### PR TITLE
Add Debian/Ubuntu dependency realpath

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -29,7 +29,7 @@ Tested on Debian 8.6 (Jessie) and Ubuntu 14.04 (Trusty) and newer.
 
    ```shell
    $ sudo apt-get install lua5.1 liblua5.1-0-dev libffi-dev gettext \
-       freeglut3-dev libsdl2-dev libosmesa6-dev python-dev python-numpy
+       freeglut3-dev libsdl2-dev libosmesa6-dev python-dev python-numpy realpath
    ```
 
 3. [Clone or download *DeepMind Lab*](https://github.com/deepmind/lab).


### PR DESCRIPTION
Got this error while building deepmind_lab.so.

ERROR: /home/XXXX/Tutorials/deepmind.com/lab/BUILD:838:1: Executing genrule //:non_pk3_assets failed: linux-sandbox failed: error executing command /home/XXXX/.cache/bazel/_bazel_XXXX/8dd5bbf380f71b193510ada22371097d/execroot/lab/_bin/linux-sandbox ... (remaining 5 argument(s) skipped).
/bin/bash: realpath: command not found

Installing realpath fixes this error.
