### PR TITLE
Fixed a problem with linking the math library on ubuntu 14.04 and 16.04

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -537,7 +537,7 @@ cc_binary(
         "-DQDECL=",
         "-pthread",
     ],
-    linkopts = ["-pthread"],
+    linkopts = ["-pthread", "-lm"],
     visibility = ["//deepmind/level_generation:__subpackages__"],
     deps = ["@zlib_archive//:zlib"],
 )
@@ -908,7 +908,7 @@ cc_binary(
         ":non_pk3_assets",
         ":vm_pk3",
     ],
-    linkopts = ["-lGL"],
+    linkopts = ["-lGL", "-lm"],
     deps = [
         ":game_lib_sdl",
         "//deepmind/engine:callbacks",


### PR DESCRIPTION
This fixes issue #6.
It now works on both 14.04 and 16.04.

Math libraries were not properly linked in both :game and :bspc.