### PR TITLE
fix 'glib_probes.h not found' build error in some environments

### DIFF
--- a/glib.BUILD
+++ b/glib.BUILD
@@ -14,7 +14,7 @@ genrule(
         "config.h",
         "glibconfig.h",
     ],
-    cmd = "./$(location configure) --disable-fam " +
+    cmd = "./$(location configure) --disable-fam --enable-dtrace=no " +
           "&& cp --verbose -- config.h $(location config.h)" +
           "&& cp --verbose -- glib/glibconfig.h $(location glibconfig.h)",
 )


### PR DESCRIPTION
The error is because glib_probes.h is generated when dtrace is available in env, but bazel script doesn't copy this file to build path. To fix this, we can simply disable dtrace tracing(not useful in 'lab' usecase)