### PR TITLE
Add experimental python 3 support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1038,3 +1038,67 @@ py_test(
     main = "python/random_agent_test.py",
     deps = [":random_agent"],
 )
+
+cc_binary(
+    name = "deepmind_lab_py3.so",
+    srcs = [
+        "public/dmlab.h",
+        "python3/dmlab_module.c",
+    ],
+    copts = [
+        "-fno-strict-aliasing",  ## ick ick ick
+        "-std=c99",
+        "-DDEEPMIND_LAB_MODULE_RUNFILES_DIR",
+    ],
+    data = [
+        ":assets_bots_pk3",
+        ":assets_oa_pk3",
+        ":assets_pk3",
+        ":map_assets",
+        ":non_pk3_assets",
+        ":vm_pk3",
+    ],
+    linkshared = 1,
+    linkstatic = 1,
+    deps = [
+        ":dmlablib",
+        "@python3_system//:python3",
+    ],
+)
+
+py_test(
+    name = "python3_module_test",
+    srcs = ["python3/dmlab_module_test.py"],
+    data = [":deepmind_lab_py3.so"],
+    imports = ["python3"],
+    main = "python3/dmlab_module_test.py",
+    default_python_version = "PY3",
+    srcs_version = "PY3",
+)
+
+py_binary(
+    name = "python3_benchmark",
+    srcs = ["python3/benchmark.py"],
+    data = [":deepmind_lab_py3.so"],
+    main = "python3/benchmark.py",
+    default_python_version = 'PY3',
+    srcs_version = 'PY3',
+)
+
+py_binary(
+    name = "random_agent_py3",
+    srcs = ["python3/random_agent.py"],
+    data = [":deepmind_lab_py3.so"],
+    main = "python3/random_agent.py",
+    default_python_version = "PY3",
+    srcs_version = "PY3",
+)
+
+py_test(
+    name = "random_agent_py3_test",
+    srcs = ["python3/random_agent_test.py"],
+    main = "python3/random_agent_test.py",
+    deps = [":random_agent_py3"],
+    default_python_version = "PY3",
+    srcs_version = "PY3",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,3 +70,9 @@ new_local_repository(
     build_file = "python.BUILD",
     path = "/usr",
 )
+new_local_repository(
+    name = "python3_system",
+    build_file = "python3.BUILD",
+    path = "/usr",
+)
+

--- a/docs/build.md
+++ b/docs/build.md
@@ -16,7 +16,7 @@ files might be required, see below.
 *DeepMind Lab* is written in C99 and C++11, and you will need a sufficiently
 modern compiler. GCC 4.8 should suffice.
 
-### Step-by-step instructions for Debian or Ubuntu
+### Step-by-step instructions for Debian or Ubuntu using Python 2
 
 Tested on Debian 8.6 (Jessie) and Ubuntu 14.04 (Trusty) and newer.
 
@@ -56,6 +56,53 @@ arguments. Run
 
 ``` shell
 lab$ bazel run :random_agent -- --help
+```
+
+to see those.
+
+### Step-by-step instructions for Debian or Ubuntu using Python 3 (Experimental)
+
+Tested on Ubuntu 16.10 (yakkety).
+
+1. Install Bazel by adding a custom APT repository, as described
+	[on the Bazel homepage](http://bazel.io/docs/install.html#ubuntu) or using
+   an [installer](https://github.com/bazelbuild/bazel/releases).
+   This should also install GCC and zip.
+
+2. Install *DeepMind Lab*'s dependencies:
+
+   ```shell
+   $ sudo apt-get install lua5.1 liblua5.1-0-dev libffi-dev gettext \
+       freeglut3-dev libsdl2-dev libosmesa6-dev python3-dev python3-numpy realpath
+   ```
+
+3. [Clone or download *DeepMind Lab*](https://github.com/deepmind/lab).
+
+4. Edit `python3.BUILD` so it maps to the correct python version (defaults to 3.5).
+	Specifically, change lines 8 and 9 to point to "include/python<your python version>".
+
+4. Build *DeepMind Lab* and run a random agent:
+
+   ```shell
+   $ cd lab
+   # Build the Python interface to DeepMind Lab with OpenGL
+   lab$ bazel build :deepmind_lab_py3.so --define headless=glx
+   # Build and run the tests for it
+   lab$ bazel run :python3_module_test --define headless=glx
+   # Rebuild the Python interface in non-headless mode and run a random agent
+   lab$ bazel run :random_agent_py3 --define headless=false
+   ```
+
+The Bazel target `:deepmind_lab_py3.so` builds the Python module that interfaces
+*DeepMind Lab*. It can be build in headless hardware rendering mode (`--define
+headless=glx`), headless software rendering mode (`--define headless=osmesa`) or
+non-headless mode (`--define headless=false`).
+
+The random agent target `:random_agent_py3` has a number of optional command line
+arguments. Run
+
+``` shell
+lab$ bazel run :random_agent_py3 -- --help
 ```
 
 to see those.

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -12,6 +12,8 @@ Constructing the environment, doing one step and retrieving one observation:
 
 ```python
 import deepmind_lab
+#For Python 3:
+#import deepmind_lab_py3 as deepmind_lab
 
 # Construct and start the environment.
 lab = deepmind_lab.Lab('seekavoid_arena_01', ['RGB_INTERLACED'])

--- a/python3.BUILD
+++ b/python3.BUILD
@@ -1,0 +1,11 @@
+# Description:
+#   Build rule for Python and Numpy.
+#   This rule works for Debian and Ubuntu. Other platforms might keep the
+#   headers in different places, cf. 'How to build DeepMind Lab' in build.md.
+
+cc_library(
+    name = "python3",
+    hdrs = glob(["include/python3.5/*.h"]),
+    includes = ["include/python3.5"],
+    visibility = ["//visibility:public"],
+)

--- a/python3/benchmark.py
+++ b/python3/benchmark.py
@@ -1,0 +1,102 @@
+# Copyright 2016 Google Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Measures DeepMind Lab performance by running low-overhead Random agent."""
+
+import argparse
+import random
+import numpy as np
+import time
+
+import deepmind_lab_py3 as deepmind_lab
+
+
+def _action(*entries):
+  return np.array(entries, dtype=np.intc)
+
+
+class DiscretizedRandomAgent(object):
+  """Simple agent for DeepMind Lab."""
+
+  ACTIONS = {
+      'strafe_left': _action(0, 0, -1, 0, 0, 0, 0),
+      'strafe_right': _action(0, 0, 1, 0, 0, 0, 0),
+      'forward': _action(0, 0, 0, 1, 0, 0, 0),
+      'backward': _action(0, 0, 0, -1, 0, 0, 0),
+      'fire': _action(0, 0, 0, 0, 1, 0, 0),
+      'crouch': _action(0, 0, 0, 0, 0, 1, 0),
+      'jump': _action(0, 0, 0, 0, 0, 0, 1)
+  }
+
+  ACTION_LIST = list(ACTIONS.values())
+
+  def step(self, unused_reward, unused_image):
+    """Gets an image state and a reward, returns an action."""
+    return random.choice(DiscretizedRandomAgent.ACTION_LIST)
+
+
+def run(length, width, height, fps, level, observation_spec):
+  """Spins up an environment and runs the random agent."""
+  env = deepmind_lab.Lab(
+      level, [observation_spec],
+      config={
+          'fps': str(fps),
+          'width': str(width),
+          'height': str(height)
+      })
+
+  env.reset()
+
+  agent = DiscretizedRandomAgent()
+
+  reward = 0
+
+  t0 = time.time()
+
+  for _ in range(length):
+    if not env.is_running():
+      print('Environment stopped early')
+      env.reset()
+      agent.reset()
+    obs = env.observations()
+    action = agent.step(reward, obs[observation_spec])
+    reward = env.step(action, num_steps=1)
+
+  t1 = time.time()
+  duration = t1 - t0
+
+  print(('resolution: %i x %i, spec: %s, steps: %i, duration: %.1f, fps: %.1f' %
+        (width, height, observation_spec, length, duration, length / duration)))
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--runfiles_path', type=str, default=None,
+                      help='Set the runfiles path to find DeepMind Lab data')
+
+  args = parser.parse_args()
+  if args.runfiles_path:
+    deepmind_lab.set_runfiles_path(args.runfiles_path)
+
+  # Test for 1 minute of simulation time at fixed in-game frame rate.
+  length = 3600
+  fps = 60
+
+  # Benchmark at each of the following levels at the specified resolutions and
+  # observation specs.
+  for level_script in ['nav_maze_static_01', 'lt_space_bounce_hard']:
+    for width, height in [(84, 84), (160, 120), (320, 240)]:
+      for observation_spec in ['RGB', 'RGBD']:
+        run(length, width, height, fps, level_script, observation_spec)

--- a/python3/dmlab_module.c
+++ b/python3/dmlab_module.c
@@ -1,0 +1,564 @@
+// Copyright (C) 2016 Google Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+// Python wrapper module for exposing the DeepMind Lab environment.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <Python.h>
+// Disallow Numpy 1.7 deprecated symbols.
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
+
+#include "public/dmlab.h"
+
+#define DEEPMIND_LAB_WRAPPER_VERSION "1.0"
+
+#define ENV_STATUS_CLOSED -3
+#define ENV_STATUS_UNINITIALIZED -2
+#define ENV_STATUS_INITIALIZED -1
+
+static char runfiles_path[4096];  // set in initdeepmind_lab() below
+
+typedef struct {
+  PyObject_HEAD
+  EnvCApi* env_c_api;
+  void* context;
+  int status;
+  int episode;
+  int* observation_indices;
+  int observation_count;
+  int num_steps;
+} LabObject;
+
+// Helper function to close the environment.
+static int env_close(LabObject* self) {
+  if (self->status != ENV_STATUS_CLOSED) {
+    self->env_c_api->release_context(self->context);
+    self->status = ENV_STATUS_CLOSED;
+    return true;
+  }
+  return false;
+}
+
+static void LabObject_dealloc(LabObject* self) {
+  env_close(self);
+  free(self->env_c_api);
+  free(self->observation_indices);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject* LabObject_new(PyTypeObject* type, PyObject* args,
+                               PyObject* kwds) {
+  LabObject* self;
+
+  self = (LabObject*)type->tp_alloc(type, 0);
+  if (self != NULL) {
+    self->env_c_api = calloc(1, sizeof *self->env_c_api);
+
+    if (self->env_c_api == NULL) {
+      PyErr_SetString(PyExc_MemoryError, "malloc failed.");
+      return NULL;
+    }
+
+    DeepMindLabLaunchParams params;
+    params.runfiles_path = runfiles_path;
+
+    if (dmlab_connect(&params, self->env_c_api, &self->context) != 0) {
+      PyErr_SetString(PyExc_RuntimeError, "Failed to connect RL API");
+      free(self->env_c_api);
+      return NULL;
+    }
+
+    if (self->env_c_api->setting(self->context, "actionSpec", "Integers")
+        != 0) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "Failed to apply 'actionSpec' setting.");
+      free(self->env_c_api);
+      return NULL;
+    }
+
+    if (self->context == NULL) {
+      Py_DECREF(self);
+      free(self->env_c_api);
+      return NULL;
+    }
+
+    self->status = ENV_STATUS_UNINITIALIZED;
+    self->episode = 0;
+  }
+
+  return (PyObject*)self;
+}
+
+static int Lab_init(LabObject* self, PyObject* args, PyObject* kwds) {
+  char* level;
+  PyObject *observations = NULL, *config = NULL;
+
+  static char* kwlist[] = {"level", "observations", "config", NULL};
+
+  if (self->env_c_api == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "RL API not setup");
+    return -1;
+  }
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "sO!|O!", kwlist, &level,
+                                   &PyList_Type, &observations, &PyDict_Type,
+                                   &config)) {
+    return -1;
+  }
+
+  if (self->env_c_api->setting(self->context, "levelName", level) != 0) {
+    PyErr_Format(PyExc_RuntimeError, "Invalid levelName flag '%s'", level);
+    return -1;
+  }
+
+  self->observation_count = PyList_Size(observations);
+  self->observation_indices = calloc(self->observation_count, sizeof(int));
+  if (self->observation_indices == NULL) {
+    PyErr_NoMemory();
+    return -1;
+  }
+
+  if (self->env_c_api->setting(self->context, "fps", "60") != 0) {
+    PyErr_SetString(PyExc_RuntimeError, "Failed to set fps");
+  }
+
+  if (config != NULL) {
+    PyObject *pykey, *pyvalue;
+    Py_ssize_t pos = 0;
+    char *key, *value;
+
+    while (PyDict_Next(config, &pos, &pykey, &pyvalue)) {
+      key = PyUnicode_AsUTF8(pykey);
+      value = PyUnicode_AsUTF8(pyvalue);
+      if (key == NULL || value == NULL) {
+        return -1;
+      }
+      if (self->env_c_api->setting(self->context, key, value) != 0) {
+        PyErr_Format(PyExc_RuntimeError, "Failed to apply setting '%s = %s'.",
+                     key, value);
+      }
+    }
+  }
+
+  if (self->env_c_api->init(self->context) != 0) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to init environment.");
+    return -1;
+  }
+
+  char* observation_name;
+  for (int i = 0; i < self->observation_count; ++i) {
+    observation_name = PyUnicode_AsUTF8(PyList_GetItem(observations, i));
+    if (observation_name == NULL) {
+      return -1;
+    }
+    int j;
+    for (j = 0; j < self->env_c_api->observation_count(self->context); ++j) {
+      if (strcmp(self->env_c_api->observation_name(self->context, j),
+                 observation_name) == 0) {
+        self->observation_indices[i] = j;
+        break;
+      }
+    }
+    if (j == self->env_c_api->observation_count(self->context)) {
+      PyErr_Format(PyExc_ValueError, "Unknown observation '%s'.",
+                   observation_name);
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+static PyObject* Lab_reset(LabObject* self, PyObject* args, PyObject* kwds) {
+  int episode = -1;
+  int seed;
+  PyObject* seed_arg = NULL;
+
+  char* kwlist[] = {"episode", "seed", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO", kwlist, &episode,
+                                   &seed_arg)) {
+    return NULL;
+  }
+
+  if (episode >= 0) {
+    self->episode = episode;
+  }
+
+  if (seed_arg == NULL || seed_arg == Py_None) {
+    seed = rand();
+  } else {
+    if (!PyLong_Check(seed_arg)) {
+      PyErr_Format(PyExc_ValueError, "'seed' must be int or None, was '%s'.",
+                   Py_TYPE(seed_arg)->tp_name);
+      return NULL;
+    }
+    seed = PyLong_AsLong(seed_arg);
+  }
+
+  if (self->env_c_api->start(self->context, self->episode, seed) != 0) {
+    PyErr_SetString(PyExc_RuntimeError, "Failed to start environment.");
+    return NULL;
+  }
+  self->num_steps = 0;
+  ++self->episode;
+  self->status = ENV_STATUS_INITIALIZED;
+  Py_RETURN_TRUE;
+}
+
+static PyObject* Lab_num_steps(LabObject* self) {
+  return PyLong_FromLong(self->num_steps);
+}
+
+// Helper function to determine if we're ready to step or give an observation.
+static int is_running(LabObject* self) {
+  switch (self->status) {
+    case ENV_STATUS_INITIALIZED:
+    case EnvCApi_EnvironmentStatus_Running:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static PyObject* Lab_is_running(LabObject* self) {
+  if (is_running(self)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
+static PyObject* Lab_step(LabObject* self, PyObject* args, PyObject* kwds) {
+  PyObject* action_obj = NULL;
+  int num_steps = 1;
+
+  char* kwlist[] = {"action", "num_steps", NULL};
+  double reward;
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|i", kwlist, &PyArray_Type,
+                                   &action_obj, &num_steps)) {
+    return NULL;
+  }
+
+  if (!is_running(self)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "Environment in wrong status to advance.");
+    return NULL;
+  }
+
+  PyArrayObject* discrete = (PyArrayObject*)action_obj;
+
+  if (PyArray_NDIM(discrete) != 1 ||
+      PyArray_DIM(discrete, 0) !=
+          self->env_c_api->action_discrete_count(self->context)) {
+    PyErr_Format(PyExc_ValueError, "action must have shape (%i)",
+                 self->env_c_api->action_discrete_count(self->context));
+    return NULL;
+  }
+
+  if (PyArray_TYPE(discrete) != NPY_INT) {
+    PyErr_SetString(PyExc_ValueError, "action must have dtype np.intc");
+    return NULL;
+  }
+
+  self->env_c_api->act(self->context, (int*)PyArray_DATA(discrete), NULL);
+
+  self->status = self->env_c_api->advance(self->context, num_steps, &reward);
+  self->num_steps += num_steps;
+  return PyFloat_FromDouble(reward);
+}
+
+// Helper function to convert our types into Numpy types
+static int ObservationType2typenum(EnvCApi_ObservationType type) {
+  switch (type) {
+    case EnvCApi_ObservationDoubles:
+      return NPY_DOUBLE;
+    case EnvCApi_ObservationBytes:
+      return NPY_UINT8;
+    default:
+      return -1;
+  }
+}
+
+static PyObject* Lab_observation_spec(LabObject* self) {
+  int count = self->env_c_api->observation_count(self->context);
+  PyObject* result = PyList_New(count);
+  if (result == NULL) {
+    PyErr_NoMemory();
+    return NULL;
+  }
+  EnvCApi_ObservationSpec spec;
+  PyObject* type;
+  PyObject* shape;
+
+  for (int i = 0; i < count; ++i) {
+    self->env_c_api->observation_spec(self->context, i, &spec);
+    type = (PyObject*)PyArray_DescrFromType(ObservationType2typenum(spec.type))
+               ->typeobj;
+    shape = PyTuple_New(spec.dims);
+    for (int j = 0; j < spec.dims; ++j) {
+      if (PyTuple_SetItem(shape, j, PyLong_FromLong(spec.shape[j])) != 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Unable to populate tuple");
+        return NULL;
+      }
+    }
+    if (PyList_SetItem(
+            result, i,
+            Py_BuildValue("{s:s,s:N,s:O}", "name",
+                          self->env_c_api->observation_name(self->context, i),
+                          "shape", shape, "dtype", type)) != 0) {
+      PyErr_SetString(PyExc_RuntimeError, "Unable to populate list");
+      return NULL;
+    }
+  }
+  return result;
+}
+
+static PyObject* Lab_fps(LabObject* self) {
+  return PyLong_FromLong(self->env_c_api->fps(self->context));
+}
+
+static PyObject* Lab_action_spec(LabObject* self) {
+  PyObject* discrete;
+
+  int count = self->env_c_api->action_discrete_count(self->context);
+  discrete = PyList_New(count);
+  if (discrete == NULL) {
+    PyErr_NoMemory();
+    return NULL;
+  }
+  int min_discrete, max_discrete;
+  for (int i = 0; i < count; ++i) {
+    self->env_c_api->action_discrete_bounds(self->context, i, &min_discrete,
+                                            &max_discrete);
+    if (PyList_SetItem(discrete, i,
+                       Py_BuildValue("{s:i,s:i,s:s}", "min", min_discrete,
+                                     "max", max_discrete, "name",
+                                     self->env_c_api->action_discrete_name(
+                                         self->context, i))) != 0) {
+      PyErr_SetString(PyExc_RuntimeError, "Unable to populate list");
+      return NULL;
+    }
+  }
+
+  return discrete;
+}
+
+static PyObject* Lab_observations(LabObject* self) {
+  PyObject* result = NULL;
+  PyArrayObject* array = NULL;
+
+  if (!is_running(self)) {
+    PyErr_SetString(PyExc_RuntimeError,
+                    "Environment in wrong status for call to observations()");
+    return NULL;
+  }
+
+  result = PyDict_New();
+  if (result == NULL) {
+    PyErr_NoMemory();
+    return NULL;
+  }
+
+  EnvCApi_Observation observation;
+  long* bounds = NULL;
+
+  for (int i = 0; i < self->observation_count; ++i) {
+    self->env_c_api->observation(self->context, self->observation_indices[i],
+                                 &observation);
+    bounds = calloc(observation.spec.dims, sizeof(long));
+    if (bounds == NULL) {
+      PyErr_NoMemory();
+      return NULL;
+    }
+    for (int j = 0; j < observation.spec.dims; ++j) {
+      bounds[j] = observation.spec.shape[j];
+    }
+    const void* src_mem = observation.spec.type == EnvCApi_ObservationDoubles
+                              ? (void*)observation.payload.doubles
+                              : (void*)observation.payload.bytes;
+    array = (PyArrayObject*)PyArray_SimpleNew(
+        observation.spec.dims, bounds,
+        ObservationType2typenum(observation.spec.type));
+    free(bounds);
+
+    if (array == NULL) {
+      PyErr_NoMemory();
+      return NULL;
+    }
+
+    memcpy(PyArray_BYTES(array), src_mem, PyArray_NBYTES(array));
+    PyDict_SetItemString(result,
+                         self->env_c_api->observation_name(
+                             self->context, self->observation_indices[i]),
+                         (PyObject*)array);
+    Py_DECREF((PyObject*)array);
+  }
+
+  return result;
+}
+
+static PyObject* Lab_close(LabObject* self) {
+  if (env_close(self)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
+static PyMethodDef LabObject_methods[] = {
+    {"reset", (PyCFunction)Lab_reset, METH_VARARGS | METH_KEYWORDS,
+     "Reset the environment"},
+    {"num_steps", (PyCFunction)Lab_num_steps, METH_NOARGS,
+     "Number of frames since the last reset() call"},
+    {"is_running", (PyCFunction)Lab_is_running, METH_NOARGS,
+     "If the environment is in status RUNNING"},
+    {"step", (PyCFunction)Lab_step, METH_VARARGS | METH_KEYWORDS,
+     "Advance the environment a number of steps"},
+    {"observation_spec", (PyCFunction)Lab_observation_spec, METH_NOARGS,
+     "The shape of the observations"},
+    {"fps", (PyCFunction)Lab_fps, METH_NOARGS,
+     "An advisory metric that correlates discrete environment steps "
+     "(\"frames\") with real (wallclock) time: the number of frames per (real) "
+     "second."},
+    {"action_spec", (PyCFunction)Lab_action_spec, METH_NOARGS,
+     "The shape of the actions"},
+    {"observations", (PyCFunction)Lab_observations, METH_NOARGS,
+     "Get the observations"},
+    {"close", (PyCFunction)Lab_close, METH_NOARGS, "Close the environment"},
+    {NULL} /* Sentinel */
+};
+
+static PyTypeObject deepmind_lab_LabType = {
+    PyVarObject_HEAD_INIT(NULL, 0)    /* ob_size */
+    "deepmind_lab.Lab",            /* tp_name */
+    sizeof(LabObject),             /* tp_basicsize */
+    0,                             /* tp_itemsize */
+    (destructor)LabObject_dealloc, /* tp_dealloc */
+    0,                             /* tp_print */
+    0,                             /* tp_getattr */
+    0,                             /* tp_setattr */
+    0,                             /* tp_compare */
+    0,                             /* tp_repr */
+    0,                             /* tp_as_number */
+    0,                             /* tp_as_sequence */
+    0,                             /* tp_as_mapping */
+    0,                             /* tp_hash */
+    0,                             /* tp_call */
+    0,                             /* tp_str */
+    0,                             /* tp_getattro */
+    0,                             /* tp_setattro */
+    0,                             /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,            /* tp_flags */
+    "Lab object",                  /* tp_doc */
+    0,                             /* tp_traverse */
+    0,                             /* tp_clear */
+    0,                             /* tp_richcompare */
+    0,                             /* tp_weaklistoffset */
+    0,                             /* tp_iter */
+    0,                             /* tp_iternext */
+    LabObject_methods,             /* tp_methods */
+    0,                             /* tp_members */
+    0,                             /* tp_getset */
+    0,                             /* tp_base */
+    0,                             /* tp_dict */
+    0,                             /* tp_descr_get */
+    0,                             /* tp_descr_set */
+    0,                             /* tp_dictoffset */
+    (initproc)Lab_init,            /* tp_init */
+    0,                             /* tp_alloc */
+    LabObject_new,                 /* tp_new */
+};
+
+static PyObject* module_runfiles_path(PyObject* self) {
+  return Py_BuildValue("s", runfiles_path);
+}
+
+static PyObject* module_set_runfiles_path(PyObject* self, PyObject* args) {
+  const char* new_path;
+  if (!PyArg_ParseTuple(args, "s", &new_path)) {
+    return NULL;
+  }
+  if (sizeof(runfiles_path) < strlen(new_path)) {
+    PyErr_SetString(PyExc_RuntimeError, "Runfiles directory name too long!");
+    return NULL;
+  }
+  strcpy(runfiles_path, new_path);
+  Py_RETURN_TRUE;
+}
+
+static PyObject* module_version(PyObject* self) {
+  return Py_BuildValue("s", DEEPMIND_LAB_WRAPPER_VERSION);
+}
+
+static PyMethodDef module_methods[] = {
+    {"version", (PyCFunction)module_version, METH_NOARGS,
+     "Module version number."},
+    {"runfiles_path", (PyCFunction)module_runfiles_path, METH_NOARGS,
+     "Get the module-wide runfiles path."},
+    {"set_runfiles_path", (PyCFunction)module_set_runfiles_path, METH_VARARGS,
+     "Set the module-wide runfiles path."},
+    {NULL, NULL, 0, NULL} /* sentinel */
+};
+
+PyMODINIT_FUNC PyInit_deepmind_lab_py3(void) {
+  PyObject* m;
+
+  if (PyType_Ready(&deepmind_lab_LabType) < 0) return;
+
+  static struct PyModuleDef moduledef = {
+      PyModuleDef_HEAD_INIT,
+      "deepmind_lab_py3",     /* m_name */
+      "DeepMind Lab API module for python 3",  /* m_doc */
+      -1,                  /* m_size */
+      module_methods,    /* m_methods */
+      NULL,                /* m_reload */
+      NULL,                /* m_traverse */
+      NULL,                /* m_clear */
+      NULL,                /* m_free */
+  };
+
+  m = PyModule_Create(&moduledef);
+
+  Py_INCREF(&deepmind_lab_LabType);
+  PyModule_AddObject(m, "Lab", (PyObject*)&deepmind_lab_LabType);
+
+#ifdef DEEPMIND_LAB_MODULE_RUNFILES_DIR
+  static const char kRunfiles[] = ".";
+#else
+  static const char kRunfiles[] = ".runfiles/org_deepmind_lab";
+  if (sizeof(runfiles_path) <
+      strlen(Py_GetProgramFullPath()) + sizeof(kRunfiles)) {
+    PyErr_SetString(PyExc_RuntimeError, "Runfiles directory name too long!");
+    return;
+  }
+  strcpy(runfiles_path, Py_GetProgramFullPath());
+#endif
+  strcat(runfiles_path, kRunfiles);
+
+  srand(time(NULL));
+
+  import_array();
+
+  return m;
+}

--- a/python3/dmlab_module_test.py
+++ b/python3/dmlab_module_test.py
@@ -1,0 +1,189 @@
+# Copyright 2016 Google Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Basic test for DeepMind Lab Python 3 wrapper."""
+
+import os
+import unittest
+import numpy as np
+
+import deepmind_lab_py3 as deepmind_lab
+
+
+class DeepMindLabTest(unittest.TestCase):
+
+  def testInitArgs(self):
+    with self.assertRaisesRegex(TypeError, 'must be dict, not list'):
+      deepmind_lab.Lab('tests/demo_map', [], ['wrongconfig'])
+    with self.assertRaisesRegex(TypeError, 'str'):
+      deepmind_lab.Lab('tests/demo_map', [], {'wrongtype': 3})
+    with self.assertRaisesRegex(TypeError, 'must be list, not None'):
+      deepmind_lab.Lab('tests/demo_map', None, {})
+    with self.assertRaisesRegex(ValueError, 'Unknown observation'):
+      deepmind_lab.Lab('tests/demo_map', ['nonexisting_obs'], {})
+
+  def testReset(self):
+    lab = deepmind_lab.Lab('tests/demo_map', [], {})
+    with self.assertRaisesRegex(ValueError,
+                                 '\'seed\' must be int or None, was \'str\''):
+      lab.reset(seed='invalid')
+
+  def testSpecs(self):
+    lab = deepmind_lab.Lab('tests/demo_map', [])
+    observation_spec = lab.observation_spec()
+    observation_names = {o['name'] for o in observation_spec}
+    action_names = {a['name'] for a in lab.action_spec()}
+
+    self.assertSetEqual(observation_names,
+                        {'RGB_INTERLACED', 'RGB', 'RGBD_INTERLACED', 'RGBD'})
+    for o in observation_spec:
+      self.assertIn('shape', o)
+      self.assertDictContainsSubset({'dtype': np.uint8}, o)
+
+    self.assertSetEqual(
+        action_names,
+        {'LOOK_LEFT_RIGHT_PIXELS_PER_FRAME',
+         'LOOK_DOWN_UP_PIXELS_PER_FRAME',
+         'STRAFE_LEFT_RIGHT',
+         'MOVE_BACK_FORWARD',
+         'FIRE',
+         'JUMP',
+         'CROUCH'})
+
+    for a in lab.action_spec():
+      self.assertIs(type(a['min']), int)
+      self.assertIs(type(a['max']), int)
+
+    self.assertTrue(lab.close())
+
+  def testOpenClose(self):
+    labs = [
+        deepmind_lab.Lab('tests/demo_map', []) for _ in range(5)]
+    for lab in labs:
+      self.assertTrue(lab.close())
+
+  def testRun(self, steps=10, observation='RGB_INTERLACED'):
+    env = deepmind_lab.Lab('lt_chasm', [observation])
+    env.reset()
+
+    for _ in range(steps):
+      obs = env.observations()
+      action = np.zeros((7,), dtype=np.intc)
+      reward = env.step(action, num_steps=4)
+
+      self.assertEqual(obs[observation].shape, (240, 320, 3))
+      self.assertEqual(reward, 0.0)
+
+  def testRunClosed(self):
+    env = deepmind_lab.Lab('lt_chasm', ['RGB_INTERLACED'])
+    env.reset(episode=42, seed=7)
+    env.close()
+
+    action = np.zeros((7,), dtype=np.intc)
+
+    with self.assertRaisesRegex(RuntimeError, 'wrong status to advance'):
+      env.step(action)
+    with self.assertRaisesRegex(RuntimeError, 'wrong status'):
+      env.observations()
+
+  def testRunfilesPath(self):
+    self.assertTrue(os.stat(deepmind_lab.runfiles_path()))
+
+  def testWidthHeight(self, width=80, height=80, steps=10, num_steps=1):
+    observations = ['RGBD']
+    env = deepmind_lab.Lab('lt_chasm', observations,
+                           config={'height': str(height),
+                                   'width': str(width)})
+    env.reset()
+
+    for _ in range(steps):
+      obs = env.observations()
+      action = np.zeros((7,), dtype=np.intc)
+      reward = env.step(action, num_steps=num_steps)
+
+      self.assertEqual(obs[observations[0]].shape, (4, width, height))
+      self.assertEqual(reward, 0.0)
+
+  def testVeloctyObservations(self, width=80, height=80):
+    noop_action = np.zeros((7,), dtype=np.intc)
+    forward_action = np.array([0, 0, 0, 1, 0, 0, 0], dtype=np.intc)
+    backward_action = - forward_action
+    look_sideways_action = np.array([512, 0, 0, 0, 0, 0, 0], dtype=np.intc)
+
+
+    env = deepmind_lab.Lab('seekavoid_arena_01', ['VEL.TRANS', 'VEL.ROT'],
+                           config={'height': str(height),
+                                   'width': str(width),
+                                   'fps': '60'})
+
+    env.reset(seed=1)
+
+    # Initial landing on the ground.
+    env.step(noop_action, num_steps=180)
+
+    for _ in range(3):
+      # Doing nothing should result in velocity observations of zero.
+      env.step(noop_action, num_steps=100)
+      obs = env.observations()
+      np.testing.assert_array_equal(obs['VEL.TRANS'], np.zeros((3,)))
+      np.testing.assert_array_equal(obs['VEL.ROT'], np.zeros((3,)))
+
+      env.step(forward_action, num_steps=100)
+      obs = env.observations()
+
+      forward_vel = obs['VEL.TRANS']
+      self.assertEqual(forward_vel[2], 0.0)  # zero velocity in z direction
+      self.assertTrue(np.any(forward_vel))
+      np.testing.assert_array_equal(obs['VEL.ROT'], np.zeros((3,)))
+
+      env.step(noop_action, num_steps=4)
+
+      # Going backward should result in negative velocity of going forward
+      env.step(backward_action, num_steps=100)
+      obs = env.observations()
+      self.assertAlmostEqual(np.linalg.norm(obs['VEL.TRANS'] + forward_vel),
+                             0.0, delta=3)
+      np.testing.assert_array_equal(obs['VEL.ROT'], np.zeros((3,)))
+
+    env.reset(seed=1)
+
+    for _ in range(3):
+      env.step(noop_action, num_steps=100)
+      obs = env.observations()
+      np.testing.assert_array_equal(obs['VEL.TRANS'], np.zeros((3,)))
+      np.testing.assert_array_equal(obs['VEL.ROT'], np.zeros((3,)))
+
+      env.step(look_sideways_action, num_steps=100)
+      obs = env.observations()
+
+      sideways_vel = obs['VEL.ROT']
+      self.assertEqual(sideways_vel[2], 0.0)
+      self.assertTrue(np.any(forward_vel))
+      np.testing.assert_array_equal(obs['VEL.TRANS'], np.zeros((3,)))
+
+      env.step(noop_action, num_steps=4)
+
+      env.step(-look_sideways_action, num_steps=100)
+      obs = env.observations()
+      self.assertAlmostEqual(np.linalg.norm(obs['VEL.ROT'] + sideways_vel),
+                             0.0, delta=3)
+      np.testing.assert_array_equal(obs['VEL.TRANS'], np.zeros((3,)))
+
+
+if __name__ == '__main__':
+  if os.environ.get('TEST_SRCDIR'):
+    deepmind_lab.set_runfiles_path(os.path.join(
+        os.environ['TEST_SRCDIR'], 'org_deepmind_lab'))
+  unittest.main()

--- a/python3/random_agent.py
+++ b/python3/random_agent.py
@@ -1,0 +1,184 @@
+# Copyright 2016 Google Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Basic random agent for DeepMind Lab."""
+
+import argparse
+import random
+import numpy as np
+
+import deepmind_lab_py3 as deepmind_lab
+
+
+def _action(*entries):
+  return np.array(entries, dtype=np.intc)
+
+
+class DiscretizedRandomAgent(object):
+  """Simple agent for DeepMind Lab."""
+
+  ACTIONS = {
+      'look_left': _action(-20, 0, 0, 0, 0, 0, 0),
+      'look_right': _action(20, 0, 0, 0, 0, 0, 0),
+      'look_up': _action(0, 10, 0, 0, 0, 0, 0),
+      'look_down': _action(0, -10, 0, 0, 0, 0, 0),
+      'strafe_left': _action(0, 0, -1, 0, 0, 0, 0),
+      'strafe_right': _action(0, 0, 1, 0, 0, 0, 0),
+      'forward': _action(0, 0, 0, 1, 0, 0, 0),
+      'backward': _action(0, 0, 0, -1, 0, 0, 0),
+      'fire': _action(0, 0, 0, 0, 1, 0, 0),
+      'jump': _action(0, 0, 0, 0, 0, 1, 0),
+      'crouch': _action(0, 0, 0, 0, 0, 0, 1)
+  }
+
+  ACTION_LIST = list(ACTIONS.values())
+
+  def step(self, unused_reward, unused_image):
+    """Gets an image state and a reward, returns an action."""
+    return random.choice(DiscretizedRandomAgent.ACTION_LIST)
+
+
+class SpringAgent(object):
+  """A random agent using spring-like forces for its action evolution."""
+
+  def __init__(self, action_spec):
+    self.action_spec = action_spec
+    print(('Starting random spring agent. Action spec:', action_spec))
+
+    self.omega = np.array([
+        0.1,  # look left-right
+        0.1,  # look up-down
+        0.1,  # strafe left-right
+        0.1,  # forward-backward
+        0.0,  # fire
+        0.0,  # jumping
+        0.0  # crouching
+    ])
+
+    self.velocity_scaling = np.array([2.5, 2.5, 0.01, 0.01, 1, 1, 1])
+
+    self.indices = {a['name']: i for i, a in enumerate(self.action_spec)}
+    self.mins = np.array([a['min'] for a in self.action_spec])
+    self.maxs = np.array([a['max'] for a in self.action_spec])
+    self.reset()
+
+    self.rewards = 0
+
+  def critically_damped_derivative(self, t, omega, displacement, velocity):
+    r"""Critical damping for movement.
+
+    I.e., x(t) = (A + Bt) \exp(-\omega t) with A = x(0), B = x'(0) + \omega x(0)
+
+    See
+      https://en.wikipedia.org/wiki/Damping#Critical_damping_.28.CE.B6_.3D_1.29
+    for details.
+
+    Args:
+      t: A float representing time.
+      omega: The undamped natural frequency.
+      displacement: The initial displacement at, x(0) in the above equation.
+      velocity: The initial velocity, x'(0) in the above equation
+
+    Returns:
+       The velocity x'(t).
+    """
+    a = displacement
+    b = velocity + omega * displacement
+    return (b - omega * t * (a + t * b)) * np.exp(-omega * t)
+
+  def step(self, reward, unused_frame):
+    """Gets an image state and a reward, returns an action."""
+    self.rewards += reward
+
+    action = (self.maxs - self.mins) * np.random.random_sample(
+        size=[len(self.action_spec)]) + self.mins
+
+    # Compute the 'velocity' 1 time unit after a critical damped force
+    # dragged us towards the random `action`, given our current velocity.
+    self.velocity = self.critically_damped_derivative(1, self.omega, action,
+                                                      self.velocity)
+
+    # Since walk and strafe are binary, we need some additional memory to
+    # smoothen the movement. Adding half of action from the last step works.
+    self.action = self.velocity / self.velocity_scaling + 0.5 * self.action
+
+    # Fire with p = 0.01 at each step
+    self.action[self.indices['FIRE']] = int(np.random.random() > 0.99)
+
+    # Jump/crouch with p = 0.005 at each step
+    self.action[self.indices['JUMP']] = int(np.random.random() > 0.995)
+    self.action[self.indices['CROUCH']] = int(np.random.random() > 0.995)
+
+    # Clip to the valid range and convert to the right dtype
+    return self.clip_action(self.action)
+
+  def clip_action(self, action):
+    return np.clip(action, self.mins, self.maxs).astype(np.intc)
+
+  def reset(self):
+    self.velocity = np.zeros([len(self.action_spec)])
+    self.action = np.zeros([len(self.action_spec)])
+
+
+def run(length, width, height, fps, level):
+  """Spins up an environment and runs the random agent."""
+  env = deepmind_lab.Lab(
+      level, ['RGB_INTERLACED'],
+      config={
+          'fps': str(fps),
+          'width': str(width),
+          'height': str(height)
+      })
+
+  env.reset()
+
+  # Starts the random spring agent. As a simpler alternative, we could also
+  # use DiscretizedRandomAgent().
+  agent = SpringAgent(env.action_spec())
+
+  reward = 0
+
+  for _ in range(length):
+    if not env.is_running():
+      print('Environment stopped early')
+      env.reset()
+      agent.reset()
+    obs = env.observations()
+    action = agent.step(reward, obs['RGB_INTERLACED'])
+    reward = env.step(action, num_steps=1)
+
+  print(('Finished after %i steps. Total reward received is %f'
+        % (length, agent.rewards)))
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--length', type=int, default=1000,
+                      help='Number of steps to run the agent')
+  parser.add_argument('--width', type=int, default=80,
+                      help='Horizontal size of the observations')
+  parser.add_argument('--height', type=int, default=80,
+                      help='Vertical size of the observations')
+  parser.add_argument('--fps', type=int, default=60,
+                      help='Number of frames per second')
+  parser.add_argument('--runfiles_path', type=str, default=None,
+                      help='Set the runfiles path to find DeepMind Lab data')
+  parser.add_argument('--level_script', type=str, default='tests/demo_map',
+                      help='The environment level script to load')
+
+  args = parser.parse_args()
+  if args.runfiles_path:
+    deepmind_lab.set_runfiles_path(args.runfiles_path)
+  run(args.length, args.width, args.height, args.fps, args.level_script)

--- a/python3/random_agent_test.py
+++ b/python3/random_agent_test.py
@@ -1,0 +1,80 @@
+# Copyright 2016 Google Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+"""Basic test for the random Python 3 agent."""
+
+import os
+import unittest
+
+import deepmind_lab_py3 as deepmind_lab
+import random_agent
+
+
+class RandomAgentsTest(unittest.TestCase):
+
+  def test_spring_agent_run(self, length=100):
+    env = deepmind_lab.Lab(
+        'tests/demo_map', ['RGB_INTERLACED'],
+        config={
+            'fps': '60',
+            'controls': 'external',
+            'width': '80',
+            'height': '80'
+        })
+
+    env.reset()
+    agent = random_agent.SpringAgent(env.action_spec())
+
+    reward = 0
+
+    for _ in range(length):
+      if not env.is_running():
+        print('Environment stopped early')
+        env.reset()
+      obs = env.observations()
+      action = agent.step(reward, obs['RGB_INTERLACED'])
+      reward = env.step(action, 1)
+      self.assertIsInstance(reward, float)
+
+  def test_discretized_random_agent_run(self, length=100):
+    env = deepmind_lab.Lab(
+        'tests/demo_map', ['RGB_INTERLACED'],
+        config={
+            'fps': '60',
+            'width': '80',
+            'height': '80'
+        })
+
+    env.reset()
+    agent = random_agent.DiscretizedRandomAgent()
+
+    reward = 0
+
+    for _ in range(length):
+      if not env.is_running():
+        print('Environment stopped early')
+        env.reset()
+      obs = env.observations()
+      action = agent.step(reward, obs['RGB_INTERLACED'])
+      reward = env.step(action, 1)
+      self.assertIsInstance(reward, float)
+
+
+if __name__ == '__main__':
+  if os.environ.get('TEST_SRCDIR'):
+    deepmind_lab.set_runfiles_path(
+        os.path.join(os.environ['TEST_SRCDIR'],
+                     'org_deepmind_lab'))
+  unittest.main()


### PR DESCRIPTION
I added a new bazel build rule for python 3 (deepmind_lab_py3.so), and added tests and examples based on the python 2 ones.  I also updated the build docs to describe how to get it working with python 3.  This addresses issues #40 and #33.