### PR TITLE
Fix to ballNearBall in psychlab

### DIFF
--- a/game_scripts/levels/contributed/psychlab/factories/motion.lua
+++ b/game_scripts/levels/contributed/psychlab/factories/motion.lua
@@ -62,8 +62,11 @@ function motion.createRandomBallMotion(opt)
   end
 
   local function ballNearBall(ballA, ballB)
-    return ballA:clone():csub(ballB):lengthSquared() <
-        motionData._minDistanceBetweenBallsSq
+    local distanceSq = 0
+    local temp = ballA:clone():csub(ballB)
+    temp:cmul(temp)
+    temp:apply(function (v) distanceSq = distanceSq + v end)
+    return distanceSq < motionData._minDistanceBetweenBallsSq
   end
 
   function motionData:illegal(tentativePosition, nextPositions)


### PR DESCRIPTION
Current implementation of ballNearBall leads to error when running multiple_object_tracking.lua with "bazel run :game" and pressing left arrow once to look at fixation cross:
Check failed: result.ok()[modifyControl] - ...pts/levels/contributed/psychlab/factories/motion.lua:65: attempt to call method 'lengthSquared' (a nil value)
stack traceback:
        ...pts/levels/contributed/psychlab/factories/motion.lua:65: in function 'ballNearBall'

Commit 36757f647500b579ceed9649c7bf3204c0eccd0a seems to have introduced this error.
Proposed change should restore intended behavior.